### PR TITLE
スタンダード第31回課題　コンバーターの申込状況の対応、条件検索機能の追加

### DIFF
--- a/src/main/java/standard/StudentManagement/controller/StudentController.java
+++ b/src/main/java/standard/StudentManagement/controller/StudentController.java
@@ -123,6 +123,25 @@ public class StudentController {
     throw new TestException("現在このAPIは利用できません。URLは｢studentList｣を利用してください。");
   }
 
+  /**
+   * 受講生の検索条件を指定して検索を行います。
+   *
+   * @param condition 検索条件（名前、メールアドレス、地域、性別、年齢範囲、コース名、申込状況、削除フラグ）
+   * @return 条件に一致した受講生一覧
+   */
+  @Operation(summary = "条件付き受講生検索", description = "指定された検索条件に一致する受講生を取得します。",
+      responses = {
+          @ApiResponse(responseCode = "200", description = "検索結果の受講生一覧",
+              content = @Content(mediaType = "application/json",
+                  schema = @Schema(implementation = Student.class))),
+          @ApiResponse(responseCode = "400", description = "検索条件が不正です",
+              content = @Content(mediaType = "application/json",
+                  schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "500", description = "サーバーエラー",
+              content = @Content(mediaType = "application/json",
+                  schema = @Schema(implementation = ErrorResponse.class)))
+      }
+  )
   @PostMapping("/searchStudents")
   public ResponseEntity<List<Student>> searchStudents(
       @RequestBody @Valid StudentSearchCondition condition) {

--- a/src/main/java/standard/StudentManagement/controller/StudentController.java
+++ b/src/main/java/standard/StudentManagement/controller/StudentController.java
@@ -17,7 +17,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import standard.StudentManagement.data.Student;
 import standard.StudentManagement.domain.StudentDetail;
+import standard.StudentManagement.domain.StudentSearchCondition;
 import standard.StudentManagement.exception.ErrorResponse;
 import standard.StudentManagement.exception.TestException;
 import standard.StudentManagement.service.StudentService;
@@ -121,5 +123,8 @@ public class StudentController {
     throw new TestException("現在このAPIは利用できません。URLは｢studentList｣を利用してください。");
   }
 
-
+  @PostMapping("/searchStudents")
+  public List<Student> searchStudents(@RequestBody StudentSearchCondition condition) {
+    return service.searchStudentByCondition(condition);
+  }
 }

--- a/src/main/java/standard/StudentManagement/controller/StudentController.java
+++ b/src/main/java/standard/StudentManagement/controller/StudentController.java
@@ -124,7 +124,10 @@ public class StudentController {
   }
 
   @PostMapping("/searchStudents")
-  public List<Student> searchStudents(@RequestBody @Valid StudentSearchCondition condition) {
-    return service.searchStudentByCondition(condition);
+  public ResponseEntity<List<Student>> searchStudents(
+      @RequestBody @Valid StudentSearchCondition condition) {
+
+    List<Student> students = service.searchStudentByCondition(condition);
+    return ResponseEntity.ok(students);
   }
 }

--- a/src/main/java/standard/StudentManagement/controller/StudentController.java
+++ b/src/main/java/standard/StudentManagement/controller/StudentController.java
@@ -124,7 +124,7 @@ public class StudentController {
   }
 
   @PostMapping("/searchStudents")
-  public List<Student> searchStudents(@RequestBody StudentSearchCondition condition) {
+  public List<Student> searchStudents(@RequestBody @Valid StudentSearchCondition condition) {
     return service.searchStudentByCondition(condition);
   }
 }

--- a/src/main/java/standard/StudentManagement/controller/converter/StudentConverter.java
+++ b/src/main/java/standard/StudentManagement/controller/converter/StudentConverter.java
@@ -4,12 +4,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
+import standard.StudentManagement.data.ApplicationStatus;
+import standard.StudentManagement.data.StatusType;
 import standard.StudentManagement.data.Student;
 import standard.StudentManagement.data.StudentCourse;
 import standard.StudentManagement.domain.StudentDetail;
 
 /**
  * 受講生詳細を受講生や受講生コース情報、もしくはその逆の変換を行うコンバーターです。
+ * 各受講生に紐づく受講生コース情報をマッピングし、さらにコースに紐づく申込状況(ApplicationStatus)も補完します。
  */
 @Component
 public class StudentConverter {
@@ -17,9 +20,10 @@ public class StudentConverter {
   /**
    * 受講生に紐づく受講生コース情報をマッピングする。
    * 受講生コース情報は受講生に対して複数存在するのでループを回して受講生詳細情報を組み立てる。
+   * コースに申込状況が存在する場合は、statusId から status（文字列）を補完して整合性を保ちます。
    *
    * @param studentList　受講生一覧
-   * @param studentCourseList　受講生コース情報のリスト
+   * @param studentCourseList　受講生コース情報のリスト(申込状況を含む)
    * @return 受講生詳細情報のリスト
    */
   public List<StudentDetail> convertStudentDetails(List<Student> studentList,
@@ -31,6 +35,14 @@ public class StudentConverter {
 
       List<StudentCourse> convertStudentCourseList = studentCourseList.stream()
           .filter(studentCourse -> student.getId().equals(studentCourse.getStudentId()))
+          .peek(course -> {
+            ApplicationStatus status = course.getApplicationStatus();
+            if (status != null
+                && status.getStatus() == null
+                && StatusType.fromId(status.getStatusId()) != null) {
+              status.setStatusId(status.getStatusId());
+            }
+          })
           .collect(Collectors.toList());
 
       studentDetail.setStudentCourseList(convertStudentCourseList);

--- a/src/main/java/standard/StudentManagement/data/Student.java
+++ b/src/main/java/standard/StudentManagement/data/Student.java
@@ -4,12 +4,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
 @Schema(description = "受講生")
 @Getter
 @Setter
+@EqualsAndHashCode
 public class Student {
 
   private String id;

--- a/src/main/java/standard/StudentManagement/domain/StudentSearchCondition.java
+++ b/src/main/java/standard/StudentManagement/domain/StudentSearchCondition.java
@@ -1,5 +1,6 @@
 package standard.StudentManagement.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -7,32 +8,37 @@ import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * 受講生の検索条件を表すクラスです。
+ * 名前やメールアドレス、地域、年齢、コース名、申込状況などの条件を指定して検索します。
+ */
+@Schema(description = "受講生の検索条件")
 @Getter
 @Setter
 public class StudentSearchCondition {
 
-  @Size(max = 100)
+  @Size(max = 100, message = "名前は100文字以内で入力してください。")
   private String name;
 
-  @Email
+  @Email(message = "正しいメールアドレス形式で入力してください。")
   private String email;
 
-  @Size(max = 100)
+  @Size(max = 100, message = "地域は100文字以内で入力してください。")
   private String area;
 
   private boolean deleted;
 
-  @Min(0)
-  @Max(150)
+  @Min(value = 0, message = "年齢は0以上を指定してください。")
+  @Max(value = 150, message = "年齢は150以下を指定してください。")
   private int minAge;
 
-  @Min(0)
-  @Max(150)
+  @Min(value = 0, message = "年齢は0以上を指定してください。")
+  @Max(value = 150, message = "年齢は150以下を指定してください。")
   private int maxAge;
 
   private String sex;
 
-  @Size(max = 100)
+  @Size(max = 100, message = "コース名は100文字以内で入力してください。")
   private String courseName;
 
   private String status;

--- a/src/main/java/standard/StudentManagement/domain/StudentSearchCondition.java
+++ b/src/main/java/standard/StudentManagement/domain/StudentSearchCondition.java
@@ -3,7 +3,6 @@ package standard.StudentManagement.domain;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
@@ -31,12 +30,10 @@ public class StudentSearchCondition {
   @Max(150)
   private int maxAge;
 
-  @Pattern(regexp = "男性|女性|その他")
   private String sex;
 
   @Size(max = 100)
   private String courseName;
 
-  @Pattern(regexp = "仮申込|本申込|受講中|受講終了")
   private String status;
 }

--- a/src/main/java/standard/StudentManagement/domain/StudentSearchCondition.java
+++ b/src/main/java/standard/StudentManagement/domain/StudentSearchCondition.java
@@ -1,5 +1,10 @@
 package standard.StudentManagement.domain;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -7,21 +12,31 @@ import lombok.Setter;
 @Setter
 public class StudentSearchCondition {
 
+  @Size(max = 100)
   private String name;
 
+  @Email
   private String email;
 
+  @Size(max = 100)
   private String area;
 
   private boolean deleted;
 
+  @Min(0)
+  @Max(150)
   private int minAge;
 
+  @Min(0)
+  @Max(150)
   private int maxAge;
 
+  @Pattern(regexp = "男性|女性|その他")
   private String sex;
 
+  @Size(max = 100)
   private String courseName;
 
+  @Pattern(regexp = "仮申込|本申込|受講中|受講終了")
   private String status;
 }

--- a/src/main/java/standard/StudentManagement/domain/StudentSearchCondition.java
+++ b/src/main/java/standard/StudentManagement/domain/StudentSearchCondition.java
@@ -1,0 +1,27 @@
+package standard.StudentManagement.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class StudentSearchCondition {
+
+  private String name;
+
+  private String email;
+
+  private String area;
+
+  private boolean deleted;
+
+  private int minAge;
+
+  private int maxAge;
+
+  private String sex;
+
+  private String courseName;
+
+  private String status;
+}

--- a/src/main/java/standard/StudentManagement/exception/GlobalExceptionHandler.java
+++ b/src/main/java/standard/StudentManagement/exception/GlobalExceptionHandler.java
@@ -1,12 +1,11 @@
 package standard.StudentManagement.exception;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-import java.util.HashMap;
-import java.util.Map;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -24,6 +23,11 @@ public class GlobalExceptionHandler {
 
   @org.springframework.web.bind.annotation.ExceptionHandler(TestException.class)
   public ResponseEntity<String> handleTestException(TestException ex){
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+  }
+
+  @org.springframework.web.bind.annotation.ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException ex) {
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
   }
 }

--- a/src/main/java/standard/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/standard/StudentManagement/repository/StudentRepository.java
@@ -5,6 +5,7 @@ import org.apache.ibatis.annotations.Mapper;
 import standard.StudentManagement.data.ApplicationStatus;
 import standard.StudentManagement.data.Student;
 import standard.StudentManagement.data.StudentCourse;
+import standard.StudentManagement.domain.StudentSearchCondition;
 
 /**
  * 受講生テーブルと受講生コース情報テーブルと紐づくリポジトリです。
@@ -92,4 +93,6 @@ public interface StudentRepository {
    * @param applicationStatus 　更新する申込状況
    */
   void updateApplicationStatus(ApplicationStatus applicationStatus);
+
+  List<Student> searchStudentByCondition(StudentSearchCondition condition);
 }

--- a/src/main/java/standard/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/standard/StudentManagement/repository/StudentRepository.java
@@ -94,5 +94,11 @@ public interface StudentRepository {
    */
   void updateApplicationStatus(ApplicationStatus applicationStatus);
 
+  /**
+   * 指定された検索条件に一致する受講生の一覧を取得します。
+   *
+   * @param condition 検索条件(名前、メールアドレス、地域、性別、年齢範囲、コース名、申込状況、削除フラグ)
+   * @return 条件に一致する受講生のリスト
+   */
   List<Student> searchStudentByCondition(StudentSearchCondition condition);
 }

--- a/src/main/java/standard/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/standard/StudentManagement/repository/StudentRepository.java
@@ -28,9 +28,10 @@ public interface StudentRepository {
   Student searchStudentById(String id);
 
   /**
-   * 受講生のコース情報の全件検索を行います。
+   * 申込状況を含む、受講生のコース情報の全件検索を行います。
+   * 各コースには、紐づく申込状況（application_statuses）が含まれる場合があります。
    *
-   * @return 受講生のコース情報(全件)
+   * @return 受講生コース情報の一覧（申込状況を含む）
    */
   List<StudentCourse> searchStudentCourseList();
 

--- a/src/main/java/standard/StudentManagement/service/StudentService.java
+++ b/src/main/java/standard/StudentManagement/service/StudentService.java
@@ -171,11 +171,18 @@ public class StudentService {
     }
   }
 
+  /**
+   * 指定された検索条件に基づいて受講生を検索します。
+   * 最小年齢が最大年齢を上回っている場合は {@link IllegalArgumentException} をスローします。
+   *
+   * @param condition 検索条件（名前、メールアドレス、地域、性別、年齢範囲、コース名、申込状況、削除フラグ）
+   * @return 条件に一致する受講生のリスト
+   * @throws IllegalArgumentException 最小年齢が最大年齢を上回っている場合
+   */
   public List<Student> searchStudentByCondition(StudentSearchCondition condition) {
     if (condition.getMinAge() > condition.getMaxAge()) {
       throw new IllegalArgumentException("最小年齢は最大年齢以下にしてください");
     }
-
     return repository.searchStudentByCondition(condition);
   }
 }

--- a/src/main/java/standard/StudentManagement/service/StudentService.java
+++ b/src/main/java/standard/StudentManagement/service/StudentService.java
@@ -172,6 +172,10 @@ public class StudentService {
   }
 
   public List<Student> searchStudentByCondition(StudentSearchCondition condition) {
+    if (condition.getMinAge() > condition.getMaxAge()) {
+      throw new IllegalArgumentException("最小年齢は最大年齢以下にしてください");
+    }
+
     return repository.searchStudentByCondition(condition);
   }
 }

--- a/src/main/java/standard/StudentManagement/service/StudentService.java
+++ b/src/main/java/standard/StudentManagement/service/StudentService.java
@@ -12,6 +12,7 @@ import standard.StudentManagement.data.ApplicationStatus;
 import standard.StudentManagement.data.Student;
 import standard.StudentManagement.data.StudentCourse;
 import standard.StudentManagement.domain.StudentDetail;
+import standard.StudentManagement.domain.StudentSearchCondition;
 import standard.StudentManagement.repository.StudentRepository;
 
 /**
@@ -168,5 +169,9 @@ public class StudentService {
     if (status != null) {
       repository.updateApplicationStatus(status);
     }
+  }
+
+  public List<Student> searchStudentByCondition(StudentSearchCondition condition) {
+    return repository.searchStudentByCondition(condition);
   }
 }

--- a/src/main/resources/mapper/studentRepository.xml
+++ b/src/main/resources/mapper/studentRepository.xml
@@ -133,7 +133,7 @@
         AND s.email LIKE CONCAT('%', #{email}, '%')
       </if>
       <if test="area != null and area != ''">
-        AND s.area = #{area}
+        AND s.area LIKE CONCAT(#{area}, '%')
       </if>
       <if test="deleted != null">
         AND s.is_deleted = #{deleted}

--- a/src/main/resources/mapper/studentRepository.xml
+++ b/src/main/resources/mapper/studentRepository.xml
@@ -15,9 +15,34 @@
     students WHERE id = #{id}
   </select>
 
-  <!-- 受講生コース情報の全件検索 -->
-  <select id="searchStudentCourseList" resultType="standard.StudentManagement.data.StudentCourse">
-    SELECT * FROM students_courses
+  <!-- 申込状況付きの受講生コース情報の全件検索 -->
+  <resultMap id="StudentCourseWithStatusMap" type="standard.StudentManagement.data.StudentCourse">
+    <id property="id" column="id"/>
+    <result property="studentId" column="student_id"/>
+    <result property="courseName" column="course_name"/>
+    <result property="startAt" column="start_at"/>
+    <result property="endAt" column="end_at"/>
+    <association property="applicationStatus" javaType="standard.StudentManagement.data.ApplicationStatus">
+      <id property="id" column="status_id"/>
+      <result property="studentCourseId" column="student_course_id"/>
+      <result property="status" column="status"/>
+      <result property="statusId" column="status_type_id"/>
+    </association>
+  </resultMap>
+
+  <select id="searchStudentCourseList" resultMap="StudentCourseWithStatusMap">
+    SELECT
+    sc.id,
+    sc.student_id,
+    sc.course_name,
+    sc.start_at,
+    sc.end_at,
+    a.id AS status_id,
+    a.student_course_id,
+    a.status,
+    a.status_id AS status_type_id
+    FROM students_courses sc
+    LEFT JOIN application_statuses a ON sc.id = a.student_course_id
   </select>
 
   <!-- 受講生IDで受講生コース検索 -->

--- a/src/main/resources/mapper/studentRepository.xml
+++ b/src/main/resources/mapper/studentRepository.xml
@@ -103,4 +103,58 @@
     WHERE id = #{id}
   </update>
 
+  <resultMap id="StudentResultMap" type="standard.StudentManagement.data.Student">
+    <id property="id" column="id"/>
+    <result property="name" column="name"/>
+    <result property="kanaName" column="kana_name"/>
+    <result property="nickname" column="nickname"/>
+    <result property="email" column="email"/>
+    <result property="area" column="area"/>
+    <result property="age" column="age"/>
+    <result property="sex" column="sex"/>
+    <result property="remark" column="remark"/>
+    <result property="deleted" column="is_deleted"/>
+  </resultMap>
+
+  <select id="searchStudentByCondition"
+    resultMap="StudentResultMap"
+    parameterType="standard.StudentManagement.domain.StudentSearchCondition">
+
+    SELECT DISTINCT s.id, s.name, s.kana_name, s.nickname, s.email, s.area, s.age, s.sex, s.remark, s.is_deleted
+    FROM students s
+    LEFT JOIN students_courses sc ON s.id = sc.student_id
+    LEFT JOIN application_statuses a ON sc.id = a.student_course_id
+
+    <where>
+      <if test="name != null and name != ''">
+        AND s.name LIKE CONCAT('%', #{name}, '%')
+      </if>
+      <if test="email != null and email != ''">
+        AND s.email LIKE CONCAT('%', #{email}, '%')
+      </if>
+      <if test="area != null and area != ''">
+        AND s.area = #{area}
+      </if>
+      <if test="deleted != null">
+        AND s.is_deleted = #{deleted}
+      </if>
+      <if test="minAge != null and minAge != ''">
+        AND s.age &gt;= #{minAge}
+      </if>
+      <if test="maxAge != null and maxAge != ''">
+        AND s.age &lt;= #{maxAge}
+      </if>
+      <if test="sex != null and sex != ''">
+        AND s.sex = #{sex}
+      </if>
+      <if test="courseName != null and courseName != ''">
+        AND sc.course_name = #{courseName}
+      </if>
+      <if test="status != null and status != ''">
+        AND a.status = #{status}
+      </if>
+    </where>
+
+  </select>
+
 </mapper>

--- a/src/main/resources/mapper/studentRepository.xml
+++ b/src/main/resources/mapper/studentRepository.xml
@@ -15,14 +15,17 @@
     students WHERE id = #{id}
   </select>
 
-  <!-- 申込状況付きの受講生コース情報の全件検索 -->
+  <!-- 申込状況を含む受講生コース情報のマッピング定義  -->
   <resultMap id="StudentCourseWithStatusMap" type="standard.StudentManagement.data.StudentCourse">
     <id property="id" column="id"/>
     <result property="studentId" column="student_id"/>
     <result property="courseName" column="course_name"/>
     <result property="startAt" column="start_at"/>
     <result property="endAt" column="end_at"/>
-    <association property="applicationStatus" javaType="standard.StudentManagement.data.ApplicationStatus">
+
+    <!-- 申込状況の関連データをマッピング-->
+    <association property="applicationStatus"
+      javaType="standard.StudentManagement.data.ApplicationStatus">
       <id property="id" column="status_id"/>
       <result property="studentCourseId" column="student_course_id"/>
       <result property="status" column="status"/>
@@ -30,6 +33,7 @@
     </association>
   </resultMap>
 
+  <!-- 全受講生コース情報と申込状況の検索 -->
   <select id="searchStudentCourseList" resultMap="StudentCourseWithStatusMap">
     SELECT
     sc.id,
@@ -103,6 +107,7 @@
     WHERE id = #{id}
   </update>
 
+  <!--　受講生情報のマッピング定義-->
   <resultMap id="StudentResultMap" type="standard.StudentManagement.data.Student">
     <id property="id" column="id"/>
     <result property="name" column="name"/>
@@ -116,6 +121,7 @@
     <result property="deleted" column="is_deleted"/>
   </resultMap>
 
+  <!--  検索条件に基づく受講生情報の検索-->
   <select id="searchStudentByCondition"
     resultMap="StudentResultMap"
     parameterType="standard.StudentManagement.domain.StudentSearchCondition">

--- a/src/test/java/standard/StudentManagement/controller/StudentControllerTest.java
+++ b/src/test/java/standard/StudentManagement/controller/StudentControllerTest.java
@@ -25,6 +25,7 @@ import standard.StudentManagement.data.ApplicationStatus;
 import standard.StudentManagement.data.Student;
 import standard.StudentManagement.data.StudentCourse;
 import standard.StudentManagement.domain.StudentDetail;
+import standard.StudentManagement.domain.StudentSearchCondition;
 import standard.StudentManagement.service.StudentService;
 
 @WebMvcTest(StudentController.class)
@@ -100,6 +101,29 @@ class StudentControllerTest {
         .andExpect(content().string("更新処理が成功しました。"));
 
     verify(service, times(1)).updateStudent(any(StudentDetail.class));
+  }
+
+  @Test
+  void searchStudents_条件を指定して検索が実行されリストが返ること() throws Exception {
+    Student testStudent = getTestStudentDetail().getStudent();
+
+    when(service.searchStudentByCondition(any())).thenReturn(
+        List.of(testStudent));
+
+    StudentSearchCondition condition = new StudentSearchCondition();
+    condition.setName("山田");
+    condition.setCourseName("Java入門");
+
+    String requestJson = objectMapper.writeValueAsString(condition);
+    String responseJson = objectMapper.writeValueAsString(List.of(testStudent));
+
+    mockMvc.perform(post("/searchStudents")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestJson))
+        .andExpect(status().isOk())
+        .andExpect(content().json(responseJson));
+
+    verify(service).searchStudentByCondition(any());
   }
 
   public StudentDetail getTestStudentDetail() {

--- a/src/test/java/standard/StudentManagement/controller/converter/StudentConverterTest.java
+++ b/src/test/java/standard/StudentManagement/controller/converter/StudentConverterTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import standard.StudentManagement.data.ApplicationStatus;
 import standard.StudentManagement.data.Student;
 import standard.StudentManagement.data.StudentCourse;
 import standard.StudentManagement.domain.StudentDetail;
@@ -76,4 +77,71 @@ class StudentConverterTest {
     assertThat(testStudentDetails.get(0).getStudentCourseList()).isEmpty();
   }
 
+  @Test
+  void convertStudentDetails_申込状況のstatusIdからstatusが補完される() {
+    Student student = new Student();
+    student.setId("test123");
+
+    StudentCourse course = new StudentCourse();
+    course.setId(100);
+    course.setStudentId("test123");
+    course.setCourseName("AWSコース");
+
+    ApplicationStatus status = new ApplicationStatus();
+    status.setStatusId(1);
+    course.setApplicationStatus(status);
+
+    List<Student> studentList = List.of(student);
+    List<StudentCourse> courseList = List.of(course);
+
+    List<StudentDetail> result = converter.convertStudentDetails(studentList, courseList);
+
+    ApplicationStatus resultStatus = result.get(0).getStudentCourseList().get(0).getApplicationStatus();
+    assertThat(resultStatus.getStatusId()).isEqualTo(1);
+    assertThat(resultStatus.getStatus()).isEqualTo("仮申込");
+  }
+
+  @Test
+  void convertStudentDetails_不正なstatusIdはstatusを補完しない() {
+    Student student = new Student();
+    student.setId("test123");
+
+    StudentCourse course = new StudentCourse();
+    course.setId(200);
+    course.setStudentId("test123");
+    course.setCourseName("AWSコース");
+
+    ApplicationStatus status = new ApplicationStatus();
+    status.setStatusId(999);
+    course.setApplicationStatus(status);
+
+    List<Student> studentList = List.of(student);
+    List<StudentCourse> courseList = List.of(course);
+
+    List<StudentDetail> result = converter.convertStudentDetails(studentList, courseList);
+
+    ApplicationStatus resultStatus = result.get(0).getStudentCourseList().get(0).getApplicationStatus();
+    assertThat(resultStatus.getStatusId()).isEqualTo(999);
+    assertThat(resultStatus.getStatus()).isNull();
+  }
+
+  @Test
+  void convertStudentDetails_申込状況がnullでも例外にならず処理できる() {
+    Student student = new Student();
+    student.setId("test123");
+
+    StudentCourse course = new StudentCourse();
+    course.setId(300);
+    course.setStudentId("test123");
+    course.setCourseName("AWSコース");
+    course.setApplicationStatus(null);
+
+    List<Student> studentList = List.of(student);
+    List<StudentCourse> courseList = List.of(course);
+
+    List<StudentDetail> result = converter.convertStudentDetails(studentList, courseList);
+
+    assertThat(result.get(0).getStudentCourseList().get(0).getCourseName()).isEqualTo("AWSコース");
+    assertThat(result.get(0).getStudentCourseList().get(0).getApplicationStatus()).isNull();
+  }
 }

--- a/src/test/java/standard/StudentManagement/domain/StudentSearchConditionValidationTest.java
+++ b/src/test/java/standard/StudentManagement/domain/StudentSearchConditionValidationTest.java
@@ -1,0 +1,120 @@
+package standard.StudentManagement.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class StudentSearchConditionValidationTest {
+
+  private Validator validator;
+
+  @BeforeEach
+  void setUp() {
+    ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    validator = factory.getValidator();
+  }
+
+  @Test
+  void 正常な入力ではバリデーションエラーが発生しないこと() {
+    StudentSearchCondition condition = new StudentSearchCondition();
+    condition.setName("山田太郎");
+    condition.setEmail("test@example.com");
+    condition.setArea("東京");
+    condition.setMinAge(20);
+    condition.setMaxAge(30);
+    condition.setSex("男性");
+    condition.setCourseName("Java入門");
+    condition.setStatus("仮申込");
+
+    Set<ConstraintViolation<StudentSearchCondition>> violations = validator.validate(condition);
+
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  void nameが101文字以上だとバリデーションエラーになること() {
+    StudentSearchCondition condition = new StudentSearchCondition();
+    condition.setName("a".repeat(101));
+
+    Set<ConstraintViolation<StudentSearchCondition>> violations = validator.validate(condition);
+
+    assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("name"));
+  }
+
+  @Test
+  void emailが不正な形式ならバリデーションエラーになること() {
+    StudentSearchCondition condition = new StudentSearchCondition();
+    condition.setEmail("not-an-email");
+
+    Set<ConstraintViolation<StudentSearchCondition>> violations = validator.validate(condition);
+
+    assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("email"));
+  }
+
+  @Test
+  void areaが101文字以上だとバリデーションエラーになること() {
+    StudentSearchCondition condition = new StudentSearchCondition();
+    condition.setArea("a".repeat(101));
+
+    Set<ConstraintViolation<StudentSearchCondition>> violations = validator.validate(condition);
+
+    assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("area"));
+  }
+
+  @Test
+  void courseNameが101文字以上だとバリデーションエラーになること() {
+    StudentSearchCondition condition = new StudentSearchCondition();
+    condition.setCourseName("a".repeat(101));
+
+    Set<ConstraintViolation<StudentSearchCondition>> violations = validator.validate(condition);
+
+    assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("courseName"));
+  }
+
+  @Test
+  void minAgeがマイナスだとバリデーションエラーになること() {
+    StudentSearchCondition condition = new StudentSearchCondition();
+    condition.setMinAge(-1);
+
+    Set<ConstraintViolation<StudentSearchCondition>> violations = validator.validate(condition);
+
+    assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("minAge"));
+  }
+
+  @Test
+  void maxAgeがマイナスだとバリデーションエラーになること() {
+    StudentSearchCondition condition = new StudentSearchCondition();
+    condition.setMaxAge(-1);
+
+    Set<ConstraintViolation<StudentSearchCondition>> violations = validator.validate(condition);
+
+    assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("maxAge"));
+  }
+
+  @Test
+  void minAgeが150を超えるとバリデーションエラーになること() {
+    StudentSearchCondition condition = new StudentSearchCondition();
+    condition.setMinAge(151);
+
+    Set<ConstraintViolation<StudentSearchCondition>> violations = validator.validate(condition);
+
+    assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("minAge"));
+  }
+
+  @Test
+  void maxAgeが150を超えるとバリデーションエラーになること() {
+    StudentSearchCondition condition = new StudentSearchCondition();
+    condition.setMaxAge(151);
+
+    Set<ConstraintViolation<StudentSearchCondition>> violations = validator.validate(condition);
+
+    assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("maxAge"));
+  }
+
+}

--- a/src/test/java/standard/StudentManagement/repository/StudentRepositoryTest.java
+++ b/src/test/java/standard/StudentManagement/repository/StudentRepositoryTest.java
@@ -330,10 +330,13 @@ class StudentRepositoryTest {
     StudentSearchCondition condition = new StudentSearchCondition();
     condition.setName("山田"); //名前はLIKE CONCAT('%', #{name}, '%')で部分一致検索される
 
+    Student student = sut.searchStudentById("11111111-1111-1111-1111-111111111111");
+    List<Student> expect = List.of(student);
+
     List<Student> result = sut.searchStudentByCondition(condition);
 
     assertThat(result).isNotEmpty();
-    assertThat(result).allMatch(student -> student.getName().contains("山田"));
+    assertThat(result).isEqualTo(expect);
   }
 
   @Test
@@ -342,11 +345,13 @@ class StudentRepositoryTest {
     condition.setName("佐藤"); //名前はLIKE CONCAT('%', #{name}, '%')で部分一致検索される
     condition.setArea("大阪"); //エリアはLIKE CONCAT(#{area}, '%')で部分一致検索される
 
+    Student student = sut.searchStudentById("22222222-2222-2222-2222-222222222222");
+    List<Student> expect = List.of(student);
+
     List<Student> result = sut.searchStudentByCondition(condition);
 
     assertThat(result).hasSize(1);
-    assertThat(result).allMatch(student -> student.getName().contains("佐藤"));
-    assertThat(result).allMatch(student -> student.getArea().contains("大阪"));
+    assertThat(result).isEqualTo(expect);
   }
 
   @Test
@@ -354,10 +359,14 @@ class StudentRepositoryTest {
     StudentSearchCondition condition = new StudentSearchCondition();
     condition.setName("田");
 
+    Student student1 = sut.searchStudentById("11111111-1111-1111-1111-111111111111");
+    Student student2 = sut.searchStudentById("44444444-4444-4444-4444-444444444444");
+    List<Student> expect = List.of(student1,student2);
+
     List<Student> result = sut.searchStudentByCondition(condition);
 
     assertThat(result).hasSize(2);
-    assertThat(result).allMatch(student -> student.getName().contains("田"));
+    assertThat(result).isEqualTo(expect);
   }
 
   @Test

--- a/src/test/java/standard/StudentManagement/service/StudentServiceTest.java
+++ b/src/test/java/standard/StudentManagement/service/StudentServiceTest.java
@@ -2,6 +2,7 @@ package standard.StudentManagement.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -233,5 +234,18 @@ class StudentServiceTest {
     assertEquals(2, result.size());
     assertEquals("山本太郎", result.get(0).getName());
     assertEquals("鈴木花子", result.get(1).getName());
+  }
+
+  @Test
+  void searchStudentByCondition_最小年齢が最大年齢より大きいとき_IllegalArgumentExceptionを投げること() {
+    StudentSearchCondition condition = new StudentSearchCondition();
+    condition.setMinAge(30);
+    condition.setMaxAge(10);
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+      sut.searchStudentByCondition(condition);
+    });
+
+    assertEquals("最小年齢は最大年齢以下にしてください", exception.getMessage());
   }
 }

--- a/src/test/java/standard/StudentManagement/service/StudentServiceTest.java
+++ b/src/test/java/standard/StudentManagement/service/StudentServiceTest.java
@@ -23,6 +23,7 @@ import standard.StudentManagement.data.ApplicationStatus;
 import standard.StudentManagement.data.Student;
 import standard.StudentManagement.data.StudentCourse;
 import standard.StudentManagement.domain.StudentDetail;
+import standard.StudentManagement.domain.StudentSearchCondition;
 import standard.StudentManagement.repository.StudentRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -98,7 +99,6 @@ class StudentServiceTest {
 
     List<StudentCourse> mockCourses = List.of(course);
 
-
     when(repository.searchStudentById(studentId)).thenReturn(mockStudent);
     when(repository.searchStudentCourseListByStudentId(studentId)).thenReturn(mockCourses);
     when(repository.searchApplicationStatusByStudentCourseId(1)).thenReturn(status);
@@ -111,7 +111,7 @@ class StudentServiceTest {
 
     assertEquals(studentId, result.getStudent().getId());
     assertEquals("山田テスト", result.getStudent().getName());
-    assertEquals("仮申込",result.getStudentCourseList().get(0).getApplicationStatus().getStatus());
+    assertEquals("仮申込", result.getStudentCourseList().get(0).getApplicationStatus().getStatus());
   }
 
   @Test
@@ -131,7 +131,7 @@ class StudentServiceTest {
 
     sut = new StudentService(repository, converter, fixedClock);
 
-    for(StudentCourse studentCourse : testCourseList){
+    for (StudentCourse studentCourse : testCourseList) {
       ApplicationStatus status = new ApplicationStatus();
       status.setStatus("仮申込");
       studentCourse.setApplicationStatus(status);
@@ -145,7 +145,7 @@ class StudentServiceTest {
       assertEquals(fixedDateTime.plusMonths(6), studentCourse.getEndAt());
     }
     verify(repository, times(2)).registerStudentCourseList(any(StudentCourse.class));
-    verify(repository,times(2)).registerApplicationStatus(any(ApplicationStatus.class));
+    verify(repository, times(2)).registerApplicationStatus(any(ApplicationStatus.class));
   }
 
   @Test
@@ -170,7 +170,7 @@ class StudentServiceTest {
 
   @Test
   void updateStudent_リポジトリの処理が適切によびだせていること() {
-    for (StudentCourse course : testCourseList){
+    for (StudentCourse course : testCourseList) {
       ApplicationStatus status = new ApplicationStatus();
       status.setStatus("仮申込");
       course.setApplicationStatus(status);
@@ -180,7 +180,7 @@ class StudentServiceTest {
 
     verify(repository).updateStudent(testStudent);
     verify(repository, times(2)).updateStudentCourseList(any(StudentCourse.class));
-    verify(repository,times(2)).updateApplicationStatus(any(ApplicationStatus.class));
+    verify(repository, times(2)).updateApplicationStatus(any(ApplicationStatus.class));
   }
 
   @Test
@@ -194,5 +194,44 @@ class StudentServiceTest {
     verify(repository).updateStudent(testStudent);
     verify(repository, times(2)).updateStudentCourseList(any(StudentCourse.class));
     verify(repository, never()).updateApplicationStatus(any());
+  }
+
+  @Test
+  void searchStudentByCondition_リポジトリの処理が適切に呼び出せていること() {
+    StudentSearchCondition condition = new StudentSearchCondition();
+    condition.setName("山本");
+
+    List<Student> mockResult = new ArrayList<>();
+    Student student = new Student();
+    student.setName("山本テスト");
+    mockResult.add(student);
+
+    when(repository.searchStudentByCondition(condition)).thenReturn(mockResult);
+
+    List<Student> result = sut.searchStudentByCondition(condition);
+
+    verify(repository, times(1)).searchStudentByCondition(condition);
+    assertEquals(1, result.size());
+    assertEquals("山本テスト", result.get(0).getName());
+  }
+
+  @Test
+  void searchStudentByCondition_検索条件がすべて空の場合_全件検索になること() {
+    StudentSearchCondition condition = new StudentSearchCondition();
+
+    List<Student> mockResult = new ArrayList<>();
+    Student student1 = new Student(); student1.setName("山本太郎");
+    Student student2 = new Student(); student2.setName("鈴木花子");
+    mockResult.add(student1);
+    mockResult.add(student2);
+
+    when(repository.searchStudentByCondition(condition)).thenReturn(mockResult);
+
+    List<Student> result = sut.searchStudentByCondition(condition);
+
+    verify(repository, times(1)).searchStudentByCondition(condition);
+    assertEquals(2, result.size());
+    assertEquals("山本太郎", result.get(0).getName());
+    assertEquals("鈴木花子", result.get(1).getName());
   }
 }


### PR DESCRIPTION
～今回やったこと～
受講生の全件検索時に申込状況も反映するように修正しました。
受講生をさまざまな条件で検索できるように、条件検索機能を追加しました。
これにより、名前・エリア・年齢・コース名・申込状況などの複数条件による柔軟な検索が可能になります。

～具体的な変更内容～
・全件検索に申込状況を反映
students_courses に申込状況を JOIN する XML マッピングを追加
StudentConverter にて、ApplicationStatus の補完処理を実装

・条件検索機能の追加
StudentSearchCondition クラス新規作成
対応フィールド：name, email, area, sex, minAge, maxAge, isDeleted, courseName, status
バリデーション（例：@Email, @Min など）とスキーマ定義追加

StudentRepository／StudentService に searchStudentByCondition() を追加
Service層で minAge > maxAge のチェックあり

StudentMapper.xml に動的 SQL（where句）を追加

StudentController に /searchStudents エンドポイント追加（POSTメソッド）
検索条件は RequestBody で受け取る形式

GlobalExceptionHandler による共通エラーハンドリングを実装

Swagger 用スキーマ定義・Javadoc も対応


Postman確認用：受講生一覧検索で申込状況が確認できる
<img width="798" height="1099" alt="スクリーンショット 2025-07-31 201707" src="https://github.com/user-attachments/assets/5225c494-9be2-410d-b69d-1c3d7caf5c73" />


条件検索
<img width="544" height="828" alt="スクリーンショット 2025-07-31 205350" src="https://github.com/user-attachments/assets/f3cd2bfc-c335-48d8-81ee-4f90791d358b" />


複数での条件検索
<img width="613" height="783" alt="スクリーンショット 2025-07-31 201719" src="https://github.com/user-attachments/assets/d3b50231-635e-4b0e-b055-9e03164aa014" />


名前の部分一致検索
<img width="542" height="1015" alt="スクリーンショット 2025-07-31 201746" src="https://github.com/user-attachments/assets/1944c878-ecb7-4d2b-942b-8814fac015ce" />


エリアの部分一致検索(県や府がなくても検索できます)
<img width="548" height="759" alt="スクリーンショット 2025-07-31 205217" src="https://github.com/user-attachments/assets/36ac12a7-3bf9-4a83-a714-8d9b1323b251" />


自動テストの結果
<img width="768" height="757" alt="スクリーンショット 2025-07-31 201611" src="https://github.com/user-attachments/assets/a0d262ea-570b-41a0-8abf-f74f3d664a33" />


～今後の予定～
問題なければ課題としては終わりですが、条件検索時にStudentで返しているのをStudnetDetailで返したり、検索条件を増やしたり画面を作ってみたりしてポートフォリオとして活用できるようにしたいです。

何か改善点があればご指摘お願いします！