### PR TITLE
chore: CD設定のEC2ホストを正しいIPに更新（動作確認用）

### DIFF
--- a/.github/workflows/JavaTest.yml
+++ b/.github/workflows/JavaTest.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   EC2_USER: 'ec2-user'
-  EC2_HOST: '13.231.182.41'
+  EC2_HOST: '13.231.185.140'
   SRC_PATH: 'build/libs/*.jar'
   DEST_PATH: '/home/ec2-user/StudentManagement.jar'
 


### PR DESCRIPTION
GitHub Actions のCD設定で使用している EC2_HOST を正しいIPに更新しました。

目的:
- デプロイジョブが正常に実行されるか確認するための動作テスト

変更内容:
- `.github/workflows/java-cd.yml` 内の EC2_HOST を修正
- その他の設定は変更なし
